### PR TITLE
IndexerHandler

### DIFF
--- a/Model/Indexer/IndexerHandler.php
+++ b/Model/Indexer/IndexerHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Zepgram, Inc. All rights reserved.
+ */
+
+namespace Zepgram\DisableSearchEngine\Model\Indexer;
+
+class IndexerHandler implements \Magento\Framework\Indexer\SaveHandler\IndexerInterface
+{
+    public function saveIndex($dimensions, \Traversable $documents)
+    {
+        return $this;
+    }
+
+    public function deleteIndex($dimensions, \Traversable $documents)
+    {
+        return $this;
+    }
+
+    public function cleanIndex($dimensions)
+    {
+        return $this;
+    }
+
+    public function isAvailable($dimensions = [])
+    {
+        return true;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -28,4 +28,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\CatalogSearch\Model\Indexer\IndexerHandlerFactory">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="none" xsi:type="string">Zepgram\DisableSearchEngine\Model\Indexer\IndexerHandler</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
I was getting `There is no such indexer handler: none` with Magento 2.4.3 during `setup:install`. This ought to fix it.