### PR TITLE
Remove elasticsearch 8 module for 2.4.8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "zepgram/module-disable-search-engine",
   "description": "Magento2 module to disable search engine and fulltext indexing for category search",
   "type": "magento2-module",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "authors": [
     {
       "name": "Benjamin Calef",
@@ -24,6 +24,7 @@
     "magento/module-elasticsearch": "*",
     "magento/module-elasticsearch-6": "*",
     "magento/module-elasticsearch-7": "*",
+    "magento/module-elasticsearch-8": "*",
     "magento/module-open-search": "*"
   },
   "autoload": {


### PR DESCRIPTION
This PR removes elasticsearch-8 module which fixes a compilation exception in Magento 2.4.8:

> There is an error in /var/www/magento2_dev/vendor/magento/module-elasticsearch-8/Model/Adapter/FieldMapper/Product/FieldProvider/FieldName/Resolver/DefaultResolver.php at line: 18
> Interface "Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\ResolverInterface" not found#0 /var/www/magento2_dev/vendor/composer/ClassLoader.php(576): include()
> ...